### PR TITLE
Fixes linting issues

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -51,6 +51,7 @@ async fn store_all_entries(log_path: &Path, entries: Vec<Entry>) -> Result<()> {
     let mut file = OpenOptions::new()
         .write(true)
         .create(true)
+        .truncate(true)
         .open(log_path)
         .context(format!("Failed to open {0}", log_path.display()))?;
 

--- a/src/settings/frequency.rs
+++ b/src/settings/frequency.rs
@@ -34,7 +34,7 @@ mod tests {
     use chrono::prelude::*;
     #[test]
     fn test_get_filename() {
-        let date = Local.ymd(2021, 4, 24);
+        let date = NaiveDate::from_ymd_opt(2021, 4, 24).unwrap();
         assert_eq!(get_filename(&Frequency::Weekly, date), "w16.md");
         assert_eq!(get_filename(&Frequency::Monthly, date), "m04.md");
         assert_eq!(get_filename(&Frequency::Bimonthly, date), "b02.md");


### PR DESCRIPTION
1. Works around clippy lint about explicitly setting truncate
2. Replaces deprecated `Local.ymd` method by NaiveData
